### PR TITLE
refactor: rename hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ Then, use the hook in your app:
 ```tsx
 'use client'
 
-import { useNeynar } from 'neynar-next'
+import { useSigner } from 'neynar-next'
 import { useCallback } from 'react'
 
 export default function LoginButton() {
-  const { signer, isLoading, signIn } = useNeynar()
+  const { signer, isLoading, signIn } = useSigner()
 
   const handleClick = useCallback(() => void signIn(), [signIn])
 
@@ -160,7 +160,7 @@ Then, hit the API from your client. This library is agnostic of your data fetchi
 ```tsx
 'use client'
 
-import { useNeynar } from 'neynar-next'
+import { useSigner } from 'neynar-next'
 import { FeedResponse, Signer } from 'neynar-next/server'
 import { useCallback } from 'react'
 import useSWRInfinite, { SWRInfiniteKeyLoader } from 'swr/infinite'
@@ -169,7 +169,7 @@ import CastPage from './cast-page'
 import styles from './casts.module.css'
 
 export default function Casts() {
-  const { signer, isLoading: signerLoading } = useNeynar()
+  const { signer, isLoading: signerLoading } = useSigner()
   const { data, isLoading, error, size, setSize } = useSWRInfinite<
     FeedResponse,
     string

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,4 +1,4 @@
 'use client'
 
 export { default as NeynarProvider } from './NeynarProvider'
-export { default as useNeynar } from './useNeynar'
+export { default as useSigner } from './useSigner'

--- a/src/client/useSigner.ts
+++ b/src/client/useSigner.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 import NeynarContext from './NeynarContext'
 
-export default function useNeynar() {
+export default function useSigner() {
   return useContext(NeynarContext)
 }


### PR DESCRIPTION
Rename hook to more accurately reflect that it only handles signer state

BREAKING CHANGE: useNeynar hook renamed to useSigner
